### PR TITLE
Hack to make issue #1 sort of work

### DIFF
--- a/fondant_deps/src/lib.rs
+++ b/fondant_deps/src/lib.rs
@@ -21,6 +21,8 @@ pub mod fondant_exports {
 }
 
 use serde::{de::DeserializeOwned, Serialize};
+use std::path::PathBuf;
+
 #[derive(Debug)]
 /// Errors that `load` and `store` can result in
 pub enum FondantError {
@@ -42,6 +44,9 @@ pub enum FondantError {
 
 /// Derive this trait on a struct to mark it as a 'configuration' struct.
 pub trait Configure: Serialize + DeserializeOwned + Default {
+    fn load_file(config_file: &PathBuf) -> Result<Self, FondantError>;
     fn load() -> Result<Self, FondantError>;
     fn store(&self) -> Result<(), FondantError>;
+    fn store_file(&self, config_file: &PathBuf) -> Result<(), FondantError>;
+
 }

--- a/fondant_derive/src/lib.rs
+++ b/fondant_derive/src/lib.rs
@@ -124,7 +124,12 @@ fn gen_impl(ast: &DeriveInput, cfg_path: ConfigPath) -> TokenStream {
         impl Configure for #struct_ident {
             fn load() -> Result<#struct_ident, FondantError> {
                 #load_paths
-                match File::open(&config_file) {
+                Self::load_file(&config_file)
+            }
+
+            fn load_file(conf_file: &PathBuf) -> Result<#struct_ident, FondantError> {
+                #load_paths        
+                match File::open(&conf_file) {  // Note: conf_file is different than config_file from #load_paths
                     Ok(mut cfg) => {
                         let mut cfg_data = String::new();
                         cfg.read_to_string(&mut cfg_data).unwrap();
@@ -146,11 +151,17 @@ fn gen_impl(ast: &DeriveInput, cfg_path: ConfigPath) -> TokenStream {
             }
             fn store(&self) -> Result<(), FondantError> {
                 #load_paths
+                &self.store_file(&config_file)?;
+                Ok(())
+            }
+
+            fn store_file(&self, conf_file: &PathBuf) -> Result<(), FondantError> {
+                #load_paths
                 let mut f = OpenOptions::new()
                     .write(true)
                     .create(true)
                     .truncate(true)
-                    .open(config_file)
+                    .open(conf_file)  // Note: conf_file is different than config_file from #load_paths
                     .map_err(|_| FondantError::FileOpenError)?;
 
                 let s = #ser::#ser_fn(self).map_err(|_| FondantError::ConfigParseError)?;


### PR DESCRIPTION
Quick and dirty hack to make it load and store files at run-time.

I think you could rewrite a good chunk of the derive as functions to to do all the directory checks etc., but that was more than I wanted to do to get basic functionality working.

One caveat, this will create the default directory and needs to read the extension of the config_file attribute to know the type of file to read/save.